### PR TITLE
Remove hardcoded secrets, use Vercel runtime config

### DIFF
--- a/supabase/functions/Deno-Edge-Function/index.ts
+++ b/supabase/functions/Deno-Edge-Function/index.ts
@@ -20,7 +20,7 @@ const DOC_LABELS: Record<string, string> = {
 };
 
 const DOC_PATHS: Record<string, string> = {
-  soc2: "https://YOUR_PROJECT_REF.supabase.co/storage/v1/object/sign/audit-docs/soc2.pdf?token=eyJraWQiOiJzdG9yYWdlLXVybC1zaWduaW5nLWtleV82NGJkMjEyMy02NmIwLTRkNjctOTVhZi02YmE5Zjg1Mjc4NDkiLCJhbGciOiJIUzI1NiJ9.eyJ1cmwiOiJhdWRpdC1kb2NzL3NvYzIucGRmIiwiaWF0IjoxNzc3NjIyMzQyLCJleHAiOjE3ODAyMTQzNDJ9.XEAHH7q8Nc5Zil1uF6Xd-DQ6s2OOLADUqEku3x-TRuk",
+  soc2: "soc2.pdf",
   iso27001: "iso27001.pdf",
   cmmc: "cmmc.pdf",
   pentest: "pentest.pdf",

--- a/supabase/functions/request-docs/index.ts
+++ b/supabase/functions/request-docs/index.ts
@@ -20,7 +20,7 @@ const DOC_LABELS: Record<string, string> = {
 };
 
 const DOC_PATHS: Record<string, string> = {
-  soc2: "https://jdagfmqrlxhiolldecxq.supabase.co/storage/v1/object/sign/audit-docs/soc2.pdf?token=eyJraWQiOiJzdG9yYWdlLXVybC1zaWduaW5nLWtleV82NGJkMjEyMy02NmIwLTRkNjctOTVhZi02YmE5Zjg1Mjc4NDkiLCJhbGciOiJIUzI1NiJ9.eyJ1cmwiOiJhdWRpdC1kb2NzL3NvYzIucGRmIiwiaWF0IjoxNzc3NjIyMzQyLCJleHAiOjE3ODAyMTQzNDJ9.XEAHH7q8Nc5Zil1uF6Xd-DQ6s2OOLADUqEku3x-TRuk",
+  soc2: "soc2.pdf",
   iso27001: "iso27001.pdf",
   cmmc: "cmmc.pdf",
   pentest: "pentest.pdf",

--- a/website/js/site.js
+++ b/website/js/site.js
@@ -1,14 +1,11 @@
 document.getElementById('year').textContent = new Date().getFullYear();
 
 // ── Request-docs form ─────────────────────────────────────────────────────────
-// Replace this URL with your Supabase project's Edge Function endpoint.
-// Format: https://<project-ref>.supabase.co/functions/v1/request-docs
-const EDGE_FUNCTION_URL = 'https://jdagfmqrlxhiolldecxq.supabase.co/functions/v1/Deno-Edge-Function';
-
-// Publishable key — safe to expose in client JS (sb_publishable_...).
-// Issued via JWT Signing Keys: Supabase Dashboard → Settings → API Keys.
-// (Legacy anon keys still work but are deprecated.)
-const SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_xtPucbBGqU9hC0aYKtGESw_9zLbY0Eq';
+// Runtime config is injected by the Vercel /api/config endpoint as window.ENV.
+// Set EDGE_FUNCTION_URL and SUPABASE_PUBLISHABLE_KEY in your Vercel project's
+// Environment Variables — never hardcode these values here.
+const EDGE_FUNCTION_URL = window.ENV?.EDGE_FUNCTION_URL ?? '';
+const SUPABASE_PUBLISHABLE_KEY = window.ENV?.SUPABASE_PUBLISHABLE_KEY ?? '';
 
 const ndaCheckbox = document.getElementById('nda-checkbox');
 const submitBtn   = document.getElementById('submit-btn');


### PR DESCRIPTION
# Description

Removes hardcoded Supabase credentials from the codebase and replaces them with runtime configuration injected by a Vercel `/api/config` endpoint. This improves security by:

1. **Eliminating exposed secrets** from source code (Supabase project ref, publishable key, and signed storage URLs)
2. **Using environment variables** via `window.ENV` object injected at runtime
3. **Simplifying document paths** to relative filenames instead of full signed URLs

## Changes

- **website/js/site.js**: Replace hardcoded `EDGE_FUNCTION_URL` and `SUPABASE_PUBLISHABLE_KEY` with runtime config from `window.ENV`
- **supabase/functions/Deno-Edge-Function/index.ts**: Simplify SOC 2 document path from full signed URL to relative filename
- **supabase/functions/request-docs/index.ts**: Simplify SOC 2 document path from full signed URL to relative filename

## Type of change
- [x] Tooling / CI
- [x] Website / external-facing content

## Compliance impact
- [x] Affects a SOC 2 control (specify: **CC6.1 - Logical and Physical Access Controls**)
- [ ] Customer-facing change
- [ ] Subprocessor change
- [ ] None

**Rationale**: Removing hardcoded secrets from source code is a fundamental security control to prevent unauthorized access to infrastructure and data.

## Checklist
- [x] No sensitive data committed (secrets removed)
- [x] Reviewers per CODEOWNERS

## Test Plan

Verify that:
1. The Vercel `/api/config` endpoint correctly injects `window.ENV` with the required variables
2. The request-docs form submission works with runtime-injected credentials
3. Document download links resolve correctly with the simplified paths

https://claude.ai/code/session_01FywJYUMkU1fTGfSwttZpdt