### PR TITLE
fix: secret scan, OWASP ZAP findings, and security hardening

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: [main, master, "claude/**", "feat/**", "fix/**"]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/vercel.json
+++ b/vercel.json
@@ -16,10 +16,31 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()" },
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "credentialless" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co; frame-ancestors 'none';"
         }
+      ]
+    },
+    {
+      "source": "/(.*)\\.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(?:js|css|woff2?|ttf|otf|eot|svg|png|jpg|jpeg|gif|ico|webp)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     }
   ]

--- a/website/index.html
+++ b/website/index.html
@@ -354,7 +354,7 @@
       <p>
         SOC 2 Type II reports, ISO 27001 SoA summaries, CMMC assessment workbooks, penetration test summaries, and security questionnaires are available under NDA. Secure download links are emailed to your work address immediately upon submission.
       </p>
-      <form id="request-form" class="request-form" onsubmit="return submitRequest(event)" novalidate>
+      <form id="request-form" class="request-form" method="post" onsubmit="return submitRequest(event)" novalidate>
         <label>Name<input type="text" name="name" required autocomplete="name"></label>
         <label>Work email<input type="email" name="email" required autocomplete="work email"></label>
         <label>Company<input type="text" name="company" required autocomplete="organization"></label>

--- a/website/js/site.js
+++ b/website/js/site.js
@@ -1,15 +1,9 @@
 document.getElementById('year').textContent = new Date().getFullYear();
 
-// ── Request-docs form ─────────────────────────────────────────────────────────
-// Runtime config is preferred from window.ENV (set via Vercel env vars +
-// /api/config). The fallback literals are the publishable/non-secret values
-// for this project and are safe to commit — they are intentionally public.
-// gitleaks allowlist: .gitleaks.toml §[allowlist] covers these patterns.
 const EDGE_FUNCTION_URL =
   window.ENV?.EDGE_FUNCTION_URL ||
   'https://jdagfmqrlxhiolldecxq.supabase.co/functions/v1/Deno-Edge-Function';
 
-// Publishable key (sb_publishable_…) — client-side only, not a secret.
 const SUPABASE_PUBLISHABLE_KEY =
   window.ENV?.SUPABASE_PUBLISHABLE_KEY ||
   'sb_publishable_xtPucbBGqU9hC0aYKtGESw_9zLbY0Eq';
@@ -84,18 +78,27 @@ async function submitRequest(e) {
   return false;
 }
 
+function safeUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' ? parsed.href : '';
+  } catch {
+    return '';
+  }
+}
+
 function showDocLinks(name, links) {
   if (!linksPanel || !requestForm) return;
 
-  // Build link cards
   const cards = links.map(l => {
-    if (!l.url) {
+    const href = safeUrl(l.url);
+    if (!href) {
       return `
         <div class="doc-link-card doc-link-unavailable">
           <div class="doc-link-info">
             <span class="doc-link-icon">📄</span>
             <div>
-              <strong>${l.label}</strong>
+              <strong>${escHtml(l.label)}</strong>
               <span class="doc-link-note">Temporarily unavailable — we'll follow up by email.</span>
             </div>
           </div>
@@ -106,11 +109,11 @@ function showDocLinks(name, links) {
         <div class="doc-link-info">
           <span class="doc-link-icon">📄</span>
           <div>
-            <strong>${l.label}</strong>
+            <strong>${escHtml(l.label)}</strong>
             <span class="doc-link-note">Link expires in 7 days</span>
           </div>
         </div>
-        <a class="btn btn-primary doc-link-btn" href="${l.url}" target="_blank" rel="noopener noreferrer">
+        <a class="btn btn-primary doc-link-btn" href="${href}" target="_blank" rel="noopener noreferrer">
           Download PDF
         </a>
       </div>`;


### PR DESCRIPTION
## Summary

- **Secret scan (gitleaks)**: Removed hardcoded JWT tokens from `DOC_PATHS` in both edge functions. Added `.gitleaks.toml` to allowlist the intentionally-public `sb_publishable_*` key in `site.js` so the CI job passes without false positives.
- **Production form fix**: Restored fallback values in `site.js` so the form works when Vercel env vars aren't configured; `window.ENV` values take precedence when set.
- **OWASP ZAP findings**: Fixed all actionable alerts from the ZAP proxy scan (see breakdown below).
- **CodeQL**: Added `codeql.yml` workflow to satisfy the branch code scanning requirement going forward.

## ZAP Finding Breakdown

| Alert | Verdict | Fix |
|---|---|---|
| SQL Injection [40018] | False positive — static site, Supabase SDK uses parameterized queries | Added `method="post"` to form as defence-in-depth to stop GET fuzzing |
| CSP / HSTS / X-Frame / X-Content-Type / Permissions-Policy | Not yet deployed | Already in `vercel.json` from this branch |
| COOP missing | Real | Added `Cross-Origin-Opener-Policy: same-origin` |
| COEP missing | Real | Added `Cross-Origin-Embedder-Policy: credentialless` (allows CDN/fonts) |
| Cross-domain misconfiguration | Real | Added `Cross-Origin-Resource-Policy: same-origin` |
| Cache-control missing | Real | HTML pages: `must-revalidate`; JS/CSS/assets: `immutable` (1 yr) |
| Suspicious comments | Real | Removed internal-tooling references from `site.js` |
| XSS via href injection | Real | Added `safeUrl()` — validates all API-returned URLs are `https://` before DOM injection; `l.label` also escaped via `escHtml()` |
| Proxy disclosure / Sec-Fetch / UA fuzzer | False positive | Vercel CDN fingerprint + ZAP request headers, unfixable at app layer |

## Test plan

- [x] Verify Vercel preview deployment shows all security headers (use browser DevTools → Network → response headers)
- [x] Submit the document request form and confirm links panel renders correctly
- [x] Confirm gitleaks CI job passes on this branch
- [x] Confirm CodeQL scan completes and uploads results (unblocks future pushes under the code scanning rule)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FywJYUMkU1fTGfSwttZpdt)_