### PR TITLE
fix: vercel route pattern and open redirect hardening

### DIFF
--- a/api/r.js
+++ b/api/r.js
@@ -2,6 +2,24 @@
 // and issues a temporary redirect. The real URL never appears in the browser.
 import { createClient } from "@supabase/supabase-js";
 
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "";
+
+// Only redirect to Supabase Storage signed URLs — prevents open redirect abuse
+// if the short_urls table were ever written to by an untrusted path.
+function isTrustedUrl(url) {
+  try {
+    const parsed = new URL(url);
+    const supabaseHost = new URL(SUPABASE_URL).hostname;
+    return (
+      parsed.protocol === "https:" &&
+      parsed.hostname === supabaseHost &&
+      parsed.pathname.startsWith("/storage/v1/object/sign/")
+    );
+  } catch {
+    return false;
+  }
+}
+
 export default async function handler(req, res) {
   const code = req.query.code;
 
@@ -9,10 +27,7 @@ export default async function handler(req, res) {
     return res.status(400).send("Invalid link.");
   }
 
-  const supabase = createClient(
-    process.env.SUPABASE_URL,
-    process.env.SUPABASE_SECRET_KEY
-  );
+  const supabase = createClient(SUPABASE_URL, process.env.SUPABASE_SECRET_KEY);
 
   const { data, error } = await supabase
     .from("short_urls")
@@ -26,6 +41,10 @@ export default async function handler(req, res) {
 
   if (new Date(data.expires_at) < new Date()) {
     return res.status(410).send("This link has expired.");
+  }
+
+  if (!isTrustedUrl(data.full_url)) {
+    return res.status(500).send("Internal error.");
   }
 
   // 302 so browsers don't cache the redirect (the underlying signed URL rotates).

--- a/vercel.json
+++ b/vercel.json
@@ -43,7 +43,7 @@
       ]
     },
     {
-      "source": "/(.*)\\.(?:js|css|woff2?|ttf|otf|eot|svg|png|jpg|jpeg|gif|ico|webp)",
+      "source": "/(.*)\\.(:ext(js|css|woff2|woff|ttf|otf|eot|svg|png|jpg|jpeg|gif|ico|webp))",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]


### PR DESCRIPTION
## Summary

Fixes the production 404 caused by an invalid `vercel.json` route pattern, plus a Semgrep open-redirect finding in the new redirect function.

- **Vercel deployment failure (404)**: `vercel.json` had an invalid `source` pattern using raw regex syntax (`(?:...)` non-capturing group, `woff2?` quantifier) that Vercel's path-to-regexp parser rejects, causing the entire deployment to fail. Replaced with `:ext(js|css|woff2|woff|...)` named-param syntax and explicit `woff2|woff` alternatives.
- **Open redirect hardening (Semgrep SAST)**: `api/r.js` now validates that the resolved `full_url` is a Supabase Storage signed URL on the correct project hostname before redirecting, preventing open-redirect abuse.

## Test plan

- [ ] Vercel deployment succeeds (no invalid source pattern error)
- [ ] `/r/<code>` redirects to the Supabase signed URL for a valid short code
- [ ] Invalid / expired short codes return 400 / 410
- [ ] Semgrep SAST passes

https://claude.ai/code/session_01LY31Q6bz9hc2SbFJ4qZWdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LY31Q6bz9hc2SbFJ4qZWdi)_