### PR TITLE
fix: correct /r/:code rewrite destination to /api/r (no .js extension)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   },
   "rewrites": [
     { "source": "/api/config", "destination": "/api/config.js" },
-    { "source": "/r/:code", "destination": "/api/r.js?code=:code" }
+    { "source": "/r/:code", "destination": "/api/r?code=:code" }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Summary

Vercel routes serverless functions **without** the file extension — `api/r.js` is served at `/api/r`, not `/api/r.js`. The previous rewrite destination `/api/r.js?code=:code` caused Vercel to return a infrastructure-level `404 NOT_FOUND` because the path didn't match any function or static file.

**Fix:** change destination from `/api/r.js?code=:code` → `/api/r?code=:code`

## Test plan

- [ ] Clicking a short URL (`/r/<code>`) no longer returns `404 NOT_FOUND`
- [ ] Short URL redirects correctly to the Supabase signed PDF URL

https://claude.ai/code/session_01LY31Q6bz9hc2SbFJ4qZWdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LY31Q6bz9hc2SbFJ4qZWdi)_