### PR TITLE
fix: isTrustedUrl falls back to *.supabase.co when SUPABASE_URL unset

### DIFF
--- a/api/r.js
+++ b/api/r.js
@@ -4,17 +4,18 @@ import { createClient } from "@supabase/supabase-js";
 
 const SUPABASE_URL = process.env.SUPABASE_URL ?? "";
 
-// Only redirect to Supabase Storage signed URLs — prevents open redirect abuse
-// if the short_urls table were ever written to by an untrusted path.
+// Only redirect to Supabase Storage signed URLs — prevents open redirect abuse.
+// Checks HTTPS + *.supabase.co hostname + signed-URL path prefix, falling back
+// to an exact hostname match when SUPABASE_URL is configured.
 function isTrustedUrl(url) {
   try {
     const parsed = new URL(url);
-    const supabaseHost = new URL(SUPABASE_URL).hostname;
-    return (
-      parsed.protocol === "https:" &&
-      parsed.hostname === supabaseHost &&
-      parsed.pathname.startsWith("/storage/v1/object/sign/")
-    );
+    if (parsed.protocol !== "https:") return false;
+    if (!parsed.pathname.startsWith("/storage/v1/object/sign/")) return false;
+    if (SUPABASE_URL) {
+      return parsed.hostname === new URL(SUPABASE_URL).hostname;
+    }
+    return parsed.hostname.endsWith(".supabase.co");
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

`isTrustedUrl()` called `new URL(SUPABASE_URL)` unconditionally. When `SUPABASE_URL` is not set in Vercel env vars it's an empty string, `new URL("")` throws, the catch block returns `false`, and every `/r/<code>` request gets a 500 "Internal error" instead of redirecting to the PDF.

**Fix:** check `SUPABASE_URL` first — if set, do the strict exact-hostname match; if not set, fall back to accepting any `*.supabase.co` host with the `/storage/v1/object/sign/` path prefix. Open-redirect protection is maintained either way.

## Test plan

- [ ] Short URL `/r/<code>` redirects to the PDF (no more 500 "Internal error")
- [ ] Setting `SUPABASE_URL` in Vercel env vars still enforces exact hostname match

https://claude.ai/code/session_01LY31Q6bz9hc2SbFJ4qZWdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LY31Q6bz9hc2SbFJ4qZWdi)_