### PR TITLE
fix: rename Vendor Security Questionnaire to Security Questionnaire

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -980,7 +980,7 @@
               </label>
               <label class="checkbox-item">
                 <input type="checkbox" name="documents" value="vsaq" />
-                <span class="checkbox-label">📝 Vendor Security Questionnaire</span>
+                <span class="checkbox-label">📝 Security Questionnaire</span>
               </label>
             </div>
           </div>


### PR DESCRIPTION
## Summary

This PR updates the label from "Vendor Security Questionnaire" to "Security Questionnaire" to match the Supabase storage naming.

## Changes

- Updated `website/index.html` line 983
- Changed checkbox label from `📝 Vendor Security Questionnaire` to `📝 Security Questionnaire`

---
*This PR was created automatically via PromptQL*