### PR TITLE
fix: Security Questionnaire checkbox value not matching Edge Function

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -979,7 +979,7 @@
                 <span class="checkbox-label">📜 Data Processing Agreement</span>
               </label>
               <label class="checkbox-item">
-                <input type="checkbox" name="documents" value="vsaq" />
+                <input type="checkbox" name="documents" value="questionnaire" />
                 <span class="checkbox-label">📝 Security Questionnaire</span>
               </label>
             </div>


### PR DESCRIPTION
## Problem

When a visitor selects "Security Questionnaire", the document is not rendered correctly. All other PDF reports work fine.

## Root Cause

The HTML checkbox for Security Questionnaire has `value="vsaq"`, but the Edge Function expects `questionnaire` as the document key.

**HTML checkbox values:** `soc2`, `iso27001`, `pentest`, `cmmc`, `dpa`, `vsaq`
**Edge Function mapping:** `questionnaire` → `questionnaire.pdf`

## Fix

Changed the checkbox value from `vsaq` to `questionnaire` to match the Edge Function's document key mapping.

---
*This PR was created automatically via PromptQL*