### PR TITLE
Add Terms of Service page

### DIFF
--- a/website/terms.html
+++ b/website/terms.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service | Trust Center</title>
+  <meta name="description" content="Terms of Service for accessing and using our Trust Center and compliance documentation.">
+  <link rel="stylesheet" href="css/styles.css">
+  <style>
+    .legal-content {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 60px 24px;
+    }
+
+    .legal-content h1 {
+      font-size: 2.5rem;
+      font-weight: 700;
+      color: #1e293b;
+      margin-bottom: 16px;
+    }
+
+    .legal-content .last-updated {
+      color: #64748b;
+      font-size: 0.875rem;
+      margin-bottom: 40px;
+      padding-bottom: 24px;
+      border-bottom: 1px solid #e2e8f0;
+    }
+
+    .legal-content h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: #1e293b;
+      margin-top: 40px;
+      margin-bottom: 16px;
+    }
+
+    .legal-content h3 {
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: #334155;
+      margin-top: 24px;
+      margin-bottom: 12px;
+    }
+
+    .legal-content p {
+      color: #475569;
+      line-height: 1.75;
+      margin-bottom: 16px;
+    }
+
+    .legal-content ul, .legal-content ol {
+      color: #475569;
+      line-height: 1.75;
+      margin-bottom: 16px;
+      padding-left: 24px;
+    }
+
+    .legal-content li {
+      margin-bottom: 8px;
+    }
+
+    .legal-content a {
+      color: #3b82f6;
+      text-decoration: none;
+    }
+
+    .legal-content a:hover {
+      text-decoration: underline;
+    }
+
+    .highlight-box {
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      padding: 20px;
+      margin: 24px 0;
+    }
+
+    .highlight-box.warning {
+      background: #fef3c7;
+      border-color: #fcd34d;
+    }
+
+    .highlight-box p:last-child {
+      margin-bottom: 0;
+    }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="index.html" class="brand">[Company] · Trust Center</a>
+      <nav>
+        <a href="index.html#frameworks">Frameworks</a>
+        <a href="index.html#controls">Controls</a>
+        <a href="index.html#privacy">Privacy</a>
+        <a href="subprocessors.html">Subprocessors</a>
+        <a href="security.html">Report Vulnerability</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="legal-content">
+    <h1>Terms of Service</h1>
+    <p class="last-updated">Last Updated: May 4, 2026</p>
+
+    <div class="highlight-box">
+      <p><strong>Summary:</strong> These Terms of Service govern your access to our Trust Center and compliance documentation. By accessing or using the Trust Center, you agree to be bound by these terms.</p>
+    </div>
+
+    <h2>1. Acceptance of Terms</h2>
+    <p>By accessing or using the Trust Center (the "Service"), you acknowledge that you have read, understood, and agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, you may not access or use the Service.</p>
+    <p>These Terms apply to all visitors, users, and others who access or use the Service, including but not limited to customers, partners, auditors, and prospective customers.</p>
+
+    <h2>2. Description of Service</h2>
+    <p>The Trust Center provides access to information regarding our security, privacy, and compliance programs, including but not limited to:</p>
+    <ul>
+      <li>Compliance framework certifications and attestations (SOC 2, ISO 27001, CMMC, etc.)</li>
+      <li>Security policies and procedures documentation</li>
+      <li>Privacy practices and data protection information</li>
+      <li>Penetration testing and security assessment reports</li>
+      <li>Data Processing Agreements (DPA)</li>
+      <li>Security questionnaire responses</li>
+      <li>Subprocessor information</li>
+    </ul>
+
+    <h2>3. Access to Documentation</h2>
+    <h3>3.1 Document Request Process</h3>
+    <p>Certain compliance documents are available upon request. To access these documents, you may be required to:</p>
+    <ul>
+      <li>Provide your name, email address, and company information</li>
+      <li>Agree to a Non-Disclosure Agreement (NDA) or confidentiality terms</li>
+      <li>Represent that you have a legitimate business purpose for accessing the documentation</li>
+    </ul>
+
+    <h3>3.2 Document Confidentiality</h3>
+    <p>Compliance documents provided through the Trust Center are confidential and proprietary. By requesting and accessing these documents, you agree to:</p>
+    <ul>
+      <li>Use the documents solely for the purpose of evaluating our security and compliance posture</li>
+      <li>Not share, distribute, or disclose the documents to any third party without our prior written consent</li>
+      <li>Not copy, reproduce, or create derivative works from the documents except as necessary for your internal evaluation</li>
+      <li>Return or destroy all copies of the documents upon request or upon termination of your business relationship with us</li>
+    </ul>
+
+    <div class="highlight-box warning">
+      <p><strong>Important:</strong> Documents provided through the Trust Center may contain watermarks identifying the requester. Any unauthorized distribution of these documents can be traced and may result in legal action.</p>
+    </div>
+
+    <h2>4. User Representations</h2>
+    <p>By using the Service, you represent and warrant that:</p>
+    <ul>
+      <li>You have the legal authority to enter into these Terms</li>
+      <li>You will provide accurate and complete information when requesting documents</li>
+      <li>You will not misrepresent your identity or affiliation</li>
+      <li>You have a legitimate business purpose for accessing our compliance documentation</li>
+      <li>You will comply with all applicable laws and regulations in your use of the Service and any documents obtained through it</li>
+    </ul>
+
+    <h2>5. Intellectual Property</h2>
+    <p>All content on the Trust Center, including but not limited to text, graphics, logos, images, documents, and software, is the property of [Company Name] or its licensors and is protected by copyright, trademark, and other intellectual property laws.</p>
+    <p>You are granted a limited, non-exclusive, non-transferable license to access and view the content solely for your internal business purposes. This license does not include the right to:</p>
+    <ul>
+      <li>Modify or create derivative works from the content</li>
+      <li>Use the content for any commercial purpose other than evaluating our services</li>
+      <li>Remove any copyright, trademark, or other proprietary notices</li>
+    </ul>
+
+    <h2>6. Disclaimer of Warranties</h2>
+    <p>THE SERVICE AND ALL CONTENT PROVIDED THROUGH IT ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. WE DISCLAIM ALL WARRANTIES, INCLUDING BUT NOT LIMITED TO:</p>
+    <ul>
+      <li>WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT</li>
+      <li>WARRANTIES THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR SECURE</li>
+      <li>WARRANTIES REGARDING THE ACCURACY, COMPLETENESS, OR RELIABILITY OF ANY CONTENT</li>
+    </ul>
+    <p>Compliance certifications and attestations are point-in-time assessments and do not guarantee ongoing compliance. Security practices and controls may change, and you should verify current status for any critical decisions.</p>
+
+    <h2>7. Limitation of Liability</h2>
+    <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, [COMPANY NAME] AND ITS OFFICERS, DIRECTORS, EMPLOYEES, AND AGENTS SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, OR BUSINESS OPPORTUNITIES, ARISING OUT OF OR RELATED TO YOUR USE OF THE SERVICE OR ANY DOCUMENTS OBTAINED THROUGH IT.</p>
+    <p>OUR TOTAL LIABILITY FOR ANY CLAIMS ARISING OUT OF OR RELATED TO THESE TERMS OR THE SERVICE SHALL NOT EXCEED ONE HUNDRED DOLLARS ($100).</p>
+
+    <h2>8. Indemnification</h2>
+    <p>You agree to indemnify, defend, and hold harmless [Company Name] and its officers, directors, employees, and agents from and against any claims, liabilities, damages, losses, and expenses, including reasonable attorneys' fees, arising out of or related to:</p>
+    <ul>
+      <li>Your use of the Service</li>
+      <li>Your violation of these Terms</li>
+      <li>Your violation of any rights of another party</li>
+      <li>Any unauthorized disclosure or distribution of documents obtained through the Service</li>
+    </ul>
+
+    <h2>9. Termination</h2>
+    <p>We reserve the right to suspend or terminate your access to the Service at any time, with or without cause, and with or without notice. Upon termination:</p>
+    <ul>
+      <li>Your right to access the Service will immediately cease</li>
+      <li>You must destroy all copies of documents obtained through the Service</li>
+      <li>Sections 5, 6, 7, 8, and 10 shall survive termination</li>
+    </ul>
+
+    <h2>10. Governing Law and Dispute Resolution</h2>
+    <p>These Terms shall be governed by and construed in accordance with the laws of the State of [State], without regard to its conflict of law provisions.</p>
+    <p>Any dispute arising out of or relating to these Terms or the Service shall be resolved through binding arbitration in accordance with the rules of the American Arbitration Association. The arbitration shall take place in [City, State], and the arbitrator's decision shall be final and binding.</p>
+
+    <h2>11. Changes to Terms</h2>
+    <p>We reserve the right to modify these Terms at any time. We will notify you of any material changes by updating the "Last Updated" date at the top of this page. Your continued use of the Service after any changes constitutes your acceptance of the new Terms.</p>
+
+    <h2>12. Contact Information</h2>
+    <p>If you have any questions about these Terms of Service, please contact us at:</p>
+    <ul>
+      <li>Email: <a href="mailto:legal@company.com">legal@company.com</a></li>
+      <li>Address: [Company Address]</li>
+    </ul>
+
+    <div class="highlight-box">
+      <p>For security-related inquiries, please visit our <a href="security.html">Security page</a> or contact our security team directly.</p>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2024 [Company Name]. All rights reserved.</p>
+      <nav>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="terms.html">Terms of Service</a>
+        <a href="security.html">Security</a>
+        <a href="subprocessors.html">Subprocessors</a>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Adds a comprehensive Terms of Service page to the Trust Center.

## Changes
- Added `website/terms.html` with full ToS content
- Page matches existing site styling (header, footer, CSS)
- Footer already links to `terms.html`

## Sections Included
- Acceptance of Terms
- Description of Service
- Access to Documentation (confidentiality & watermarking notice)
- User Representations
- Intellectual Property
- Disclaimer of Warranties
- Limitation of Liability
- Indemnification
- Termination
- Governing Law & Dispute Resolution
- Changes to Terms
- Contact Information

## Note
Replace `[Company Name]`, `[State]`, `[City, State]`, and `[Company Address]` placeholders with actual values.