### PR TITLE
fix: Update Terms of Service footer link

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1063,7 +1063,7 @@
       <p>&copy; 2024 [Company Name]. All rights reserved.</p>
       <nav>
         <a href="privacy.html">Privacy Policy</a>
-        <a href="#">Terms of Service</a>
+        <a href="terms.html">Terms of Service</a>
         <a href="security.html">Security</a>
         <a href="subprocessors.html">Subprocessors</a>
       </nav>


### PR DESCRIPTION
## Summary
Fixes the Terms of Service link in the footer to point to `terms.html` instead of `#`.

## Changes
- Updated `<a href="#">Terms of Service</a>` to `<a href="terms.html">Terms of Service</a>`

## Issue
The Terms of Service page was added in PR #26, but the footer link was still pointing to `#` (placeholder).