### PR TITLE
fix: Use company_name column instead of company

### DIFF
--- a/supabase/functions/request-documents/index.ts
+++ b/supabase/functions/request-documents/index.ts
@@ -233,7 +233,7 @@ serve(async (req) => {
         emailRedirectTo: redirectUrl,
         data: {
           request_id: requestId,
-          company: company,
+          company_name: company,
           documents: documents,
         },
       },


### PR DESCRIPTION
## Problem

The Edge Function was trying to insert into a `company` column, but the database table has `company_name`.

**Error:**
```
Could not find the 'company' column of 'document_requests' in the schema cache
```

## Fix

Changed the INSERT statement to use `company_name` instead of `company`.