### PR TITLE
fix: Use correct field names in inline script

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1248,9 +1248,9 @@
                     body: JSON.stringify({
                         fullName: fullName,
                         email: email,
-                        companyName: companyName,
+                        company: companyName,
                         documents: selectedDocs,
-                        ndaAccepted: true
+                        ndaAgreed: true
                     })
                 });
                 


### PR DESCRIPTION
## Problem

The inline script in `index.html` (lines 1248-1254) sends the wrong field names to the Edge Function:

| Sent by inline script | Expected by Edge Function |
|----------------------|---------------------------|
| `companyName` | `company` |
| `ndaAccepted` | `ndaAgreed` |

This caused the validation to fail with "Company name is required" even when the user filled in the form.

## Fix

Changed the inline script to use the correct field names:
- `companyName: companyName` → `company: companyName`
- `ndaAccepted: true` → `ndaAgreed: true`

## Note

PR #33 fixed the database column name (`company` → `company_name`), but that fix was never reached because validation failed first due to this field name mismatch.