### PR TITLE
fix: Add Authorization header for Edge Function calls

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1077,6 +1077,7 @@
     <script>
         // === TRUST CENTER DOCUMENT REQUEST FORM ===
         const SUPABASE_EDGE_FUNCTION_URL = 'https://jdagfmqrlxhiolldecxq.supabase.co/functions/v1/request-documents';
+        const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpkYWdmbXFybHhoaW9sbGRlY3hxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Mzc2NTk2MTQsImV4cCI6MjA1MzIzNTYxNH0.gDmWrDpG2GDXV7EAKIXoKMFD_e5R__kzdrC1tYzzxD4';
 
         // Status message helper
         function showStatus(message, type = 'info') {
@@ -1243,7 +1244,8 @@
                 const response = await fetch(SUPABASE_EDGE_FUNCTION_URL, {
                     method: 'POST',
                     headers: {
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
                     },
                     body: JSON.stringify({
                         fullName: fullName,


### PR DESCRIPTION
## Problem

The Edge Function call in the inline script is missing the `Authorization` header with the Supabase anon key. This causes Supabase to reject the request with a 401 Unauthorized error.

## Fix

1. Added `SUPABASE_ANON_KEY` constant
2. Added `Authorization: Bearer ${SUPABASE_ANON_KEY}` header to the fetch call

## Note

Supabase Edge Functions require authentication even for public endpoints. The anon key is safe to expose in client-side code as it only grants limited permissions defined by Row Level Security policies.